### PR TITLE
Update version to 1.0.2 and optimize line particle count for performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # User-specific stuff
 .idea/
+.vscode/
 
 *.iml
 *.ipr

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.funnyboyroks</groupId>
     <artifactId>DrawLib</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>DrawLib</name>

--- a/src/main/java/com/funnyboyroks/drawlib/renderer/ShapeRenderer.java
+++ b/src/main/java/com/funnyboyroks/drawlib/renderer/ShapeRenderer.java
@@ -33,7 +33,7 @@ public class ShapeRenderer {
     private Color        color; // Colour of the particles to be drawn
     private List<Player> receivers; // Players that will receive the particles
     private boolean      force; // Force show particles
-    private double step_size = .2; // Step between two particles
+    private double       step_size = .1; // Step between two particles
     private boolean      optimize; // Optimize particles
 
     public ShapeRenderer() {
@@ -138,8 +138,9 @@ public class ShapeRenderer {
         // |  term  |                          middle                             |  term  |
         // ********** * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **********
         if (this.optimize && length >= lengthOfStartOptimize) {
-            final int term = 10;   // number of terminal points
-            final int middle = 80; // number of middle points
+            final double ppb = 1.0 / step_size; // points per block
+            final int term = (int)(lengthOfTerm * ppb); // number of terminal points
+            final int middle = (int)(lengthOfMinMiddle * ppb); // number of middle points
             final int max = term * 2 + middle; // max points on line
             for (int i = 0; i <= max; i++) {
                 double mag;  // 0.0 ~ 1.0

--- a/src/main/java/com/funnyboyroks/drawlib/renderer/ShapeRenderer.java
+++ b/src/main/java/com/funnyboyroks/drawlib/renderer/ShapeRenderer.java
@@ -33,12 +33,14 @@ public class ShapeRenderer {
     private Color        color; // Colour of the particles to be drawn
     private List<Player> receivers; // Players that will receive the particles
     private boolean      force; // Force show particles
-    private double step_size = .1; // Step between two particles
+    private double step_size = .2; // Step between two particles
+    private boolean      optimize; // Optimize particles
 
     public ShapeRenderer() {
         this.color = Color.RED;
         this.receivers = null;
         this.force = false;
+        this.optimize = true;
     }
 
     /**
@@ -57,6 +59,13 @@ public class ShapeRenderer {
         }
 
         this.step_size = step_size;
+    }
+
+    /**
+     * @param optimize Optimize plot line
+     */
+    public void setOptimize(boolean optimize) {
+        this.optimize = optimize;
     }
 
     /**
@@ -121,12 +130,38 @@ public class ShapeRenderer {
 
         Vector vec = new Vector(b.getX() - a.getX(), b.getY() - a.getY(), b.getZ() - a.getZ());
 
-        Vector unit = vec.getUnit();
+        double length = vec.getMag();
+        final double lengthOfTerm = 2.0;  // terminal length = 2.0 blocks
+        final double lengthOfMinMiddle = 8.0;
+        final double lengthOfStartOptimize = lengthOfTerm * 2 + lengthOfMinMiddle;
+        // |<--------------------------------- length ------------------------------------>|
+        // |  term  |                          middle                             |  term  |
+        // ********** * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **********
+        if (this.optimize && length >= lengthOfStartOptimize) {
+            final int term = 10;   // number of terminal points
+            final int middle = 80; // number of middle points
+            final int max = term * 2 + middle; // max points on line
+            for (int i = 0; i <= max; i++) {
+                double mag;  // 0.0 ~ 1.0
+                if (i >= term + middle) {
+                    mag = (length - lengthOfTerm + ((double)(i - (term + middle)) / term) * lengthOfTerm) / length;
+                } else if (i < term) {
+                    mag = ((double) i / term) * lengthOfTerm / length;
+                } else {
+                    mag = (lengthOfTerm + ((double)(i - term) / middle) * (length - lengthOfTerm * 2)) / length;
+                }
+                Location l = vec.clone().mult(mag).toLocation(a.getWorld());
+                l.add(a);
+                drawPoint(l);
+            }
+        } else {
+            Vector unit = vec.getUnit();
 
-        for (double mag = 0; mag * mag < vec.getMagSq(); mag += step_size) {
-            Location l = unit.clone().mult(mag).toLocation(a.getWorld());
-            l.add(a);
-            drawPoint(l);
+            for (double mag = 0; mag * mag < vec.getMagSq(); mag += step_size) {
+                Location l = unit.clone().mult(mag).toLocation(a.getWorld());
+                l.add(a);
+                drawPoint(l);
+            }
         }
 
     }


### PR DESCRIPTION
The server becomes unresponsive when drawing long lines, so we have limited the number of particles in one line.
The density of particles is increased only at both ends of the line.

For [worldedit-selection-viewer](https://github.com/funnyboy-roks/worldedit-selection-viewer)

![image](https://github.com/user-attachments/assets/9ed89a92-b16c-4b5b-bfce-43eba5be5703)
